### PR TITLE
Request for try_with_pretty_error_log modification

### DIFF
--- a/lib/app/models/open_object_resource.rb
+++ b/lib/app/models/open_object_resource.rb
@@ -147,8 +147,9 @@ class OpenObjectResource < ActiveResource::Base
           raise e
         end
         raise e unless openerp_error_hash.is_a? Hash
-        logger.error "*********** OpenERP Server ERROR:\n#{openerp_error_hash["faultString"]}***********"
-        raise RuntimeError.new('OpenERP server error')
+	    error_msg = "*********** OpenERP Server ERROR:\n#{openerp_error_hash["faultString"]}***********"
+        logger.error error_msg
+        raise RuntimeError.new(error_msg)
     end
 
     def clean_request_args!(args)


### PR DESCRIPTION
Hello Raphaël,

I explain my problematic : in an application which uses ooor, we insert new lines in OpenERP.
Some of the inserts raise an exception because data isn't conform to the DB constraints like null values in mandatory columns or integrity constraints.
I have to output a log in a new file each invalid line with the openerp error.

The problem now is that the full error message returned by openerp is output in the logger but the ooor exception itself only returns the message : "OpenERP server error" so I can't parse and re-use the error message.

In our code :
    begin
        @current_erp_object = @oerpClass.new(data) 
        @current_erp_object.create()
    rescue Exception => e
        # parse and use exception message 
        # but e = 'OpenERP server error'
    end

So I modified the try_with_pretty_error_log to return the full message when the exception is raised.

If you think about a better solution, let's go with it, but I guess I won't be the only one which will encounter that need.

Thank you,
Regards,
Guewen Baconnier
