### PR TITLE
New method in ooor : each_by_packets

### DIFF
--- a/spec/ooor_spec.rb
+++ b/spec/ooor_spec.rb
@@ -328,6 +328,32 @@ describe Ooor do
       end
     end
 
+    describe "Each by packets" do
+      it "should returns the same total number of lines as find(:all) method" do
+        partners = ResPartner.find(:all, :fields=>["id", "name"])
+        each_partners_size = ResPartner.each_by_packet(:per_packet => 5, :fields=>["id", "name"])
+        partners.size.should == each_partners_size
+      end
+
+      it "should execute the each block as many times as lines count" do
+        each_count = 0
+        each_partners_size = ResPartner.each_by_packet(:per_packet => 5, :fields=>["id", "name"]) do |partner|
+          each_count += 1
+        end
+        each_count.should == each_partners_size
+      end
+
+      it "should be able to use same arguments as find method" do
+        each_partners_count = ResPartner.each_by_packet(:per_packet => 5,
+                                                        :domain => [['supplier', '=', 1],['active','=',1]],
+                                                        :fields => ["id", "name"],
+                                                        :context => {'lang' => 'es_ES'}) do |partner|
+          partner.name.should_not be_nil
+        end
+      end
+
+    end
+
   end
 
 


### PR DESCRIPTION
Hello,

I added a new method to ooor for a needs that we have. 
I think that it is quite generic to propose you a merge.

The need is the following :
We have a big table in OpenERP, for example AccountAnalyticLine (more than 100'000 rows). 
We have to do something on ALL rows. A migration for example.

Try do to a AccountAnalyticLine.find(:all), you can go take a coffee, and when you come back, you'll only see someting like :

```
/home/gbaconnier/.rvm/rubies/ruby-1.8.7-p334/lib/ruby/1.8/timeout.rb:64:in `rbuf_fill': execution expired (Timeout::Error)
```

So this method does :
- Get find :all with same arguments requested but only with 'id' field
- Iterate on each ids 100 by 100 (or :per_packet argument) 
- Do a find :all with the ids of the packet and the 
- On each id, execute the block

So you can do 

```
AccountAnalyticLine.each_by_packet(:per_packet => 50) do |line| 
  # stuff
  line.save
end
```

The whole data of each line will be computed only by packets of how many items you want.

Regards
Guewen

Edit. : I mean AccountAnalyticLine. Instead of AccountAnalyticAccount, of course.
