### PR TITLE
Replacing RAILS_ENV constant by Rails.env for Rails 3 bootstrap

### DIFF
--- a/lib/ooor.rb
+++ b/lib/ooor.rb
@@ -135,7 +135,7 @@ module Ooor
     if Rails.version[0] == "3"[0] #Rails 3 bootstrap
       class Railtie < Rails::Railtie
         initializer "ooor.middleware" do |app|
-          Ooor.default_config = Ooor.load_config(false, RAILS_ENV)
+          Ooor.default_config = Ooor.load_config(false, Rails.env)
           Ooor.default_ooor = Ooor.new(Ooor.default_config) if Ooor.default_config['bootstrap']
         end
       end


### PR DESCRIPTION
Replacing RAILS_ENV constant by Rails.env for Rails 3 bootstrap (gets rid of deprecation warning) :

DEPRECATION WARNING: RAILS_ENV is deprecated. Please use ::Rails.env. (called from <top (required)> at /Users/dom/test/config/environment.rb:5)
