### PR TITLE
Ensure date is always 0 padded

### DIFF
--- a/lib/app/models/type_casting.rb
+++ b/lib/app/models/type_casting.rb
@@ -37,9 +37,9 @@ module Ooor
         elsif !v.is_a?(Integer) && !v.is_a?(Float) && v.is_a?(Numeric) && v.respond_to?(:to_f)
           return v.to_f
         elsif !v.is_a?(Numeric) && !v.is_a?(Integer) && v.respond_to?(:sec) && v.respond_to?(:year)#really ensure that's a datetime type
-          return "#{v.year}-#{v.month}-#{v.day} #{v.hour}:#{v.min}:#{v.sec}"
+          return "%d-%02d-%02d %02d:%02d:%02d" % [v.year, v.month, v.day, v.hour, v.min, v.sec]
         elsif !v.is_a?(Numeric) && !v.is_a?(Integer) && v.respond_to?(:day) && v.respond_to?(:year)#really ensure that's a date type
-          return "#{v.year}-#{v.month}-#{v.day}"
+          return "%d-%02d-%02d" % [v.year, v.month, v.day]
         elsif v == "false" #may happen with OOORBIT
           return false
         else


### PR DESCRIPTION
When the month, day, hour, minute or second are less than 10, ooor formats them like : '2012-4-20 0:0:0'.
This does work with OpenERP (we use v5). However, by default OpenERP loads them in the format: '2012-04-20 00:00:00'. Because, OpenERP loads dates as strings, this sometimes causes us issues. The patch just ensure that the date is alway 0 padded.
