### PR TITLE
        Fixing error shown when OpenERP database name supplied is wrong ...

### DIFF
--- a/lib/ooor/services.rb
+++ b/lib/ooor/services.rb
@@ -42,12 +42,15 @@ module Ooor
           req.body = {method: 'call', params: { db: db, login: username, password: password}}.to_json
         end
         @session.web_session[:cookie] = response.headers["set-cookie"]
+        json_response = JSON.parse(response.body)
+        validate_response(json_response)
+
         if response.status == 200
           sid_part1 = @session.web_session[:cookie].split("sid=")[1]
           if sid_part1
             @session.web_session[:sid] = @session.web_session[:cookie].split("sid=")[1].split(";")[0] # NOTE side is required on v7 but not on v8, this enables to sniff if we are on v7
           end
-          json_response = JSON.parse(response.body)
+          
           @session.web_session[:session_id] = json_response['result']['session_id']
           user_id = json_response['result']['uid']
           @session.config[:user_id] = user_id
@@ -56,6 +59,17 @@ module Ooor
         else
           raise Faraday::Error::ClientError.new(response.status, response)
         end
+      end
+    end
+
+    private
+    # Function to validate json response with useful messages
+    # Eg: For Database database "<DB NAME>" does not exist errors from open erb.
+    def validate_response(json_response)
+      error = json_response["error"]
+
+      if error && error["data"]["type"] == "server_exception"
+        raise "#{error["message"]} ------- #{error["data"]["debug"]}"
       end
     end
   end


### PR DESCRIPTION
Fixing error shown below when OpenERP database name supplied is wrong to OOOr client
Added a validate method with more informative stack trace.

/home/kannan/.rvm/gems/ruby-2.2.1/gems/ooor-2.1.0/lib/ooor/services.rb:51:in login': undefined method[]' for nil:NilClass (NoMethodError)
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/ooor-2.1.0/lib/ooor/services.rb:85:in object_service' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/ooor-2.1.0/lib/ooor/session.rb:98:inread_model_data'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/ooor-2.1.0/lib/ooor/session.rb:84:in load_models' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/ooor-2.1.0/lib/ooor/session.rb:47:inglobal_login'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/ooor-2.1.0/lib/ooor/railtie.rb:15:in block in <class:Railtie>' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:30:ininstance_exec'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:30:in run' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:55:inblock in run_initializers'
from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:226:in block in tsort_each' from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:348:inblock (2 levels) in each_strongly_connected_component'
from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:429:in each_strongly_connected_component_from' from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:347:inblock in each_strongly_connected_component'
from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:345:in each' from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:345:incall'
from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:345:in each_strongly_connected_component' from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:224:intsort_each'
from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:203:in tsort_each' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:54:inrun_initializers'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/application.rb:352:in initialize!' from /home/kannan/Documents/7NODES/external-projects/Metawarelabs-projects/pands/config/environment.rb:5:in'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274:in require' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274:inblock in require'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:240:in load_dependency' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274:inrequire'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/spring-1.2.0/lib/spring/application.rb:92:in preload' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/spring-1.2.0/lib/spring/application.rb:143:inserve'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/spring-1.2.0/lib/spring/application.rb:131:in block in run' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/spring-1.2.0/lib/spring/application.rb:125:inloop'
from /home/kannan/.rvm/gems/ruby-2.2.1/gems/spring-1.2.0/lib/spring/application.rb:125:in run' from /home/kannan/.rvm/gems/ruby-2.2.1/gems/spring-1.2.0/lib/spring/application/boot.rb:18:in'
from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in require' from /home/kannan/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:inrequire'
from -e:1:in `

'