### PR TITLE
[IMP] add the possibility to use variable env into ooor.yml

### DIFF
--- a/lib/ooor/railtie.rb
+++ b/lib/ooor/railtie.rb
@@ -30,7 +30,8 @@ module Ooor
 
     def load_config(config_file=nil, env=nil)
       config_file ||= defined?(Rails.root) && "#{Rails.root}/config/ooor.yml" || 'ooor.yml'
-      @config = HashWithIndifferentAccess.new(::YAML.load_file(config_file)[env || 'development'])
+      config_parsed = ::YAML.load(ERB.new(File.new(config_file).read).result)
+      @config = HashWithIndifferentAccess.new(config_parsed)[env || 'development']
     rescue SystemCallError
       Ooor.logger.error """failed to load OOOR yaml configuration file.
          make sure your app has a #{config_file} file correctly set up


### PR DESCRIPTION
Hi Raph

I have add an erb templating on ooor.yml like in mongoid https://github.com/mongoid/mongoid/blob/994f1aecfd56d5810c5af840c8698d055b4a7cb5/lib/mongoid/config.rb#L129

Now we can use env variable to set the login/password of odoo without risk of commiting it in the git historic

Example:


production:
  url: <%= ENV["ODOO_URL"] %>
  database: <%= ENV["ODOO_DB"] %>
  username: <%= ENV["ODOO_USER"] %>
  password: <%= ENV["ODOO_PASSWORD"] %>
